### PR TITLE
Scan configs from json, yaml, and toml

### DIFF
--- a/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordDropDown.kt
+++ b/modules/core/src/main/kotlin/com/metalbear/mirrord/MirrordDropDown.kt
@@ -193,7 +193,11 @@ class MirrordConfigIndex : ScalarIndexExtension<String>() {
 
     override fun getInputFilter(): FileBasedIndex.InputFilter {
         return FileBasedIndex.InputFilter {
-            it.isInLocalFileSystem && !it.isDirectory && it.path.endsWith("mirrord.json")
+            it.isInLocalFileSystem && !it.isDirectory && (
+                it.path.endsWith("mirrord.json") ||
+                    it.path.endsWith("mirrord.yaml") ||
+                    it.path.endsWith("mirrord.toml")
+            )
         }
     }
 


### PR DESCRIPTION
According to the [doc](https://mirrord.dev/docs/overview/quick-start/#intellij-plugin), mirrord supports three extensions, json, yaml, and toml. So the plugin should scan them all.

Please make sure you added a CHANGELOG file in `changelog.d/` named `issue_number.category.md`.
For example, `1054.changed.md` or `+towncrier.added.md` (if no issue).